### PR TITLE
feat: enable smaa image loading detection

### DIFF
--- a/src/effects/SMAAEffect.js
+++ b/src/effects/SMAAEffect.js
@@ -144,7 +144,7 @@ export class SMAAEffect extends Effect {
 			const onSMAAImageLoaded = () => {
 
 				nbImagesLoaded++;
-				if (nbImagesLoaded === 2) this.dispatchEvent("loaded");
+				if (nbImagesLoaded === 2) this.dispatchEvent("load");
 
 			}
 

--- a/src/effects/SMAAEffect.js
+++ b/src/effects/SMAAEffect.js
@@ -136,8 +136,17 @@ export class SMAAEffect extends Effect {
 		// Load the lookup textures.
 		if(typeof Image !== "undefined") {
 
+			let nbImagesLoaded = 0;
+
 			const searchImage = new Image();
 			const areaImage = new Image();
+
+			const onSMAAImageLoaded = () => {
+
+				nbImagesLoaded++;
+				if (nbImagesLoaded === 2) this.dispatchEvent("loaded");
+
+			}
 
 			searchImage.addEventListener("load", () => {
 
@@ -149,6 +158,7 @@ export class SMAAEffect extends Effect {
 				searchTexture.needsUpdate = true;
 				searchTexture.flipY = true;
 				this.weightsMaterial.searchTexture = searchTexture;
+				onSMAAImageLoaded();
 
 			});
 
@@ -162,6 +172,7 @@ export class SMAAEffect extends Effect {
 				areaTexture.needsUpdate = true;
 				areaTexture.flipY = false;
 				this.weightsMaterial.areaTexture = areaTexture;
+				onSMAAImageLoaded()
 
 			});
 


### PR DESCRIPTION
### Description

Since 6.26.0 there is no way to detect when SMAA images are done loading.
This could be useful in a "render on demand" context for an example.

With this PR:
```js
const smaaEffect = new SMAAEffect();
smaaEffect.addEventListener('load', () => {
  // do something
});
```

By the way, thanks for the awesome library, we use it and love it at Spline 🙌 .

Edit: renamed "loaded" to "load" in example
