### PR TITLE
fix: add types fields to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,13 @@
 	"exports": {
 		".": {
 			"import": "./build/postprocessing.esm.js",
-			"require": "./build/postprocessing.js"
+			"require": "./build/postprocessing.js",
+			"types": "./types/postprocessing.d.ts"
 		},
-		"./module": "./build/postprocessing.mjs"
+		"./module": {
+			"import": "./build/postprocessing.mjs",
+			"types": "./types/postprocessing.d.ts"
+		}
 	},
 	"types": "types/postprocessing.d.ts",
 	"sideEffects": false,


### PR DESCRIPTION
### Description

Since 4.9, [Typescript prioritises the `exports` field](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#exports-is-prioritized-over-typesversions) over `typesVersions` and `types`. 
