### PR TITLE
Converted SSAOMaterial camera uniforms to references

### DIFF
--- a/src/materials/CircleOfConfusionMaterial.js
+++ b/src/materials/CircleOfConfusionMaterial.js
@@ -282,7 +282,7 @@ export class CircleOfConfusionMaterial extends ShaderMaterial {
 			this.uniforms.cameraNear.value = camera.near;
 			this.uniforms.cameraFar.value = camera.far;
 
-			if(camera instanceof PerspectiveCamera) {
+			if(camera instanceof PerspectiveCamera || camera.type === 'PerspectiveCamera') {
 
 				this.defines.PERSPECTIVE_CAMERA = "1";
 

--- a/src/materials/DepthComparisonMaterial.js
+++ b/src/materials/DepthComparisonMaterial.js
@@ -110,7 +110,7 @@ export class DepthComparisonMaterial extends ShaderMaterial {
 			this.uniforms.cameraNear.value = camera.near;
 			this.uniforms.cameraFar.value = camera.far;
 
-			if(camera instanceof PerspectiveCamera) {
+			if(camera instanceof PerspectiveCamera || camera.type === 'PerspectiveCamera') {
 
 				this.defines.PERSPECTIVE_CAMERA = "1";
 

--- a/src/materials/DepthMaskMaterial.js
+++ b/src/materials/DepthMaskMaterial.js
@@ -46,7 +46,8 @@ export class DepthMaskMaterial extends ShaderMaterial {
 				inputBuffer: new Uniform(null),
 				depthBuffer0: new Uniform(null),
 				depthBuffer1: new Uniform(null),
-				cameraNearFar: new Uniform(new Vector2(1, 1))
+				cameraNear: new Uniform(0.3),
+				cameraFar: new Uniform(1000),
 			},
 			blending: NoBlending,
 			depthWrite: false,
@@ -361,9 +362,10 @@ export class DepthMaskMaterial extends ShaderMaterial {
 
 		if(camera) {
 
-			this.uniforms.cameraNearFar.value.set(camera.near, camera.far);
+			this.uniforms.cameraNear.value = camera.near;
+			this.uniforms.cameraFar.value = camera.far;
 
-			if(camera instanceof PerspectiveCamera) {
+			if(camera instanceof PerspectiveCamera || camera.type === 'PerspectiveCamera') {
 
 				this.defines.PERSPECTIVE_CAMERA = "1";
 

--- a/src/materials/EffectMaterial.js
+++ b/src/materials/EffectMaterial.js
@@ -367,7 +367,7 @@ export class EffectMaterial extends ShaderMaterial {
 			this.uniforms.cameraNear.value = camera.near;
 			this.uniforms.cameraFar.value = camera.far;
 
-			if(camera instanceof PerspectiveCamera) {
+			if(camera instanceof PerspectiveCamera || camera.type === "PerspectiveCamera") {
 
 				this.defines.PERSPECTIVE_CAMERA = "1";
 

--- a/src/materials/SSAOMaterial.js
+++ b/src/materials/SSAOMaterial.js
@@ -90,7 +90,7 @@ export class SSAOMaterial extends ShaderMaterial {
 
 	get near() {
 
-		return this.uniforms.cameraNearFar.value.x;
+		return this.uniforms.cameraNear.value;
 
 	}
 
@@ -103,7 +103,7 @@ export class SSAOMaterial extends ShaderMaterial {
 
 	get far() {
 
-		return this.uniforms.cameraNearFar.value.y;
+		return this.uniforms.cameraFar.value;
 
 	}
 
@@ -829,7 +829,7 @@ export class SSAOMaterial extends ShaderMaterial {
 			this.uniforms.cameraNear.value = camera.near;
 			this.uniforms.cameraFar.value = camera.far;
 			this.uniforms.projectionMatrix.value = camera.projectionMatrix;
-			this.uniforms.inverseProjectionMatrix.value. = camera.projectionMatrix.invert();
+			this.uniforms.inverseProjectionMatrix.value = camera.projectionMatrixInverse;
 
 			if(camera instanceof PerspectiveCamera) {
 

--- a/src/materials/SSAOMaterial.js
+++ b/src/materials/SSAOMaterial.js
@@ -39,7 +39,7 @@ export class SSAOMaterial extends ShaderMaterial {
 				inverseProjectionMatrix: new Uniform(new Matrix4()),
 				projectionMatrix: new Uniform(new Matrix4()),
 				texelSize: new Uniform(new Vector2()),
-				cameraNear: new Uniform(0.03),
+				cameraNear: new Uniform(0.3),
 				cameraFar: new Uniform(1000),
 				distanceCutoff: new Uniform(new Vector2()),
 				proximityCutoff: new Uniform(new Vector2()),
@@ -831,7 +831,7 @@ export class SSAOMaterial extends ShaderMaterial {
 			this.uniforms.projectionMatrix.value = camera.projectionMatrix;
 			this.uniforms.inverseProjectionMatrix.value = camera.projectionMatrixInverse;
 
-			if(camera instanceof PerspectiveCamera) {
+			if(camera instanceof PerspectiveCamera || camera.type === 'PerspectiveCamera') {
 
 				this.defines.PERSPECTIVE_CAMERA = "1";
 

--- a/src/materials/SSAOMaterial.js
+++ b/src/materials/SSAOMaterial.js
@@ -39,7 +39,8 @@ export class SSAOMaterial extends ShaderMaterial {
 				inverseProjectionMatrix: new Uniform(new Matrix4()),
 				projectionMatrix: new Uniform(new Matrix4()),
 				texelSize: new Uniform(new Vector2()),
-				cameraNearFar: new Uniform(new Vector2()),
+				cameraNear: new Uniform(0.03),
+				cameraFar: new Uniform(1000),
 				distanceCutoff: new Uniform(new Vector2()),
 				proximityCutoff: new Uniform(new Vector2()),
 				noiseScale: new Uniform(new Vector2()),
@@ -825,9 +826,10 @@ export class SSAOMaterial extends ShaderMaterial {
 
 		if(camera) {
 
-			this.uniforms.cameraNearFar.value.set(camera.near, camera.far);
-			this.uniforms.projectionMatrix.value.copy(camera.projectionMatrix);
-			this.uniforms.inverseProjectionMatrix.value.copy(camera.projectionMatrix).invert();
+			this.uniforms.cameraNear.value = camera.near;
+			this.uniforms.cameraFar.value = camera.far;
+			this.uniforms.projectionMatrix.value = camera.projectionMatrix;
+			this.uniforms.inverseProjectionMatrix.value. = camera.projectionMatrix.invert();
 
 			if(camera instanceof PerspectiveCamera) {
 

--- a/src/materials/glsl/depth-mask.frag
+++ b/src/materials/glsl/depth-mask.frag
@@ -14,17 +14,18 @@
 #endif
 
 uniform sampler2D inputBuffer;
-uniform vec2 cameraNearFar;
+uniform float cameraNear;
+uniform float cameraFar;
 
 float getViewZ(const in float depth) {
 
 	#ifdef PERSPECTIVE_CAMERA
 
-		return perspectiveDepthToViewZ(depth, cameraNearFar.x, cameraNearFar.y);
+		return perspectiveDepthToViewZ(depth, cameraNear, cameraFar);
 
 	#else
 
-		return orthographicDepthToViewZ(depth, cameraNearFar.x, cameraNearFar.y);
+		return orthographicDepthToViewZ(depth, cameraNear, cameraFar);
 
 	#endif
 
@@ -61,8 +62,8 @@ void main() {
 	#ifdef PERSPECTIVE_CAMERA
 
 		// Linearize.
-		depth.x = viewZToOrthographicDepth(getViewZ(depth.x), cameraNearFar.x, cameraNearFar.y);
-		depth.y = viewZToOrthographicDepth(getViewZ(depth.y), cameraNearFar.x, cameraNearFar.y);
+		depth.x = viewZToOrthographicDepth(getViewZ(depth.x), cameraNear, cameraFar);
+		depth.y = viewZToOrthographicDepth(getViewZ(depth.y), cameraNear, cameraFar);
 
 	#endif
 

--- a/src/materials/glsl/ssao.frag
+++ b/src/materials/glsl/ssao.frag
@@ -58,7 +58,9 @@ uniform lowp sampler2D noiseTexture;
 uniform mat4 inverseProjectionMatrix;
 uniform mat4 projectionMatrix;
 uniform vec2 texelSize;
-uniform vec2 cameraNearFar;
+
+uniform float cameraNear;
+uniform float cameraFar;
 
 uniform float intensity;
 uniform float minRadiusScale;
@@ -75,11 +77,11 @@ float getViewZ(const in float depth) {
 
 	#ifdef PERSPECTIVE_CAMERA
 
-		return perspectiveDepthToViewZ(depth, cameraNearFar.x, cameraNearFar.y);
+		return perspectiveDepthToViewZ(depth, cameraNear, cameraFar);
 
 	#else
 
-		return orthographicDepthToViewZ(depth, cameraNearFar.x, cameraNearFar.y);
+		return orthographicDepthToViewZ(depth, cameraNear, cameraFar);
 
 	#endif
 
@@ -135,7 +137,7 @@ float getAmbientOcclusion(const in vec3 p, const in vec3 n, const in float depth
 
 		#ifdef PERSPECTIVE_CAMERA
 
-			float linearSampleDepth = viewZToOrthographicDepth(viewZ, cameraNearFar.x, cameraNearFar.y);
+			float linearSampleDepth = viewZToOrthographicDepth(viewZ, cameraNear, cameraFar);
 
 		#else
 
@@ -186,7 +188,7 @@ void main() {
 
 	#ifdef PERSPECTIVE_CAMERA
 
-		float linearDepth = viewZToOrthographicDepth(viewZ, cameraNearFar.x, cameraNearFar.y);
+		float linearDepth = viewZToOrthographicDepth(viewZ, cameraNear, cameraFar);
 
 	#else
 


### PR DESCRIPTION
The rest of the material that use the camera near/far clip planes use references to the camera.near/.far, so that if the camera updates the near/far copyCameraSettings doesn't need to be called again.

Made SSAOMaterial work in the same way, so that I don't need to set the camera every time the near/far changes.
Also made the projectionMatrix and inverseProjectionMatrix references to the same camera properties, for same reason as above.

This is a critical bug for me, the SSAOEffect does not work until this is fixed.
