### PR TITLE
DepthOfFieldEffect: disable premult alpha in opaque rendering

### DIFF
--- a/src/effects/DepthOfFieldEffect.js
+++ b/src/effects/DepthOfFieldEffect.js
@@ -180,7 +180,7 @@ export class DepthOfFieldEffect extends Effect {
 
 		this.maskPass = new ShaderPass(new MaskMaterial(this.renderTargetCoC.texture));
 		const maskMaterial = this.maskPass.fullscreenMaterial;
-		maskMaterial.maskFunction = MaskFunction;
+		maskMaterial.maskFunction = MaskFunction.MULTIPLY;
 		maskMaterial.colorChannel = ColorChannel.GREEN;
 
 		/**

--- a/src/effects/DepthOfFieldEffect.js
+++ b/src/effects/DepthOfFieldEffect.js
@@ -180,7 +180,7 @@ export class DepthOfFieldEffect extends Effect {
 
 		this.maskPass = new ShaderPass(new MaskMaterial(this.renderTargetCoC.texture));
 		const maskMaterial = this.maskPass.fullscreenMaterial;
-		maskMaterial.maskFunction = MaskFunction.MULTIPLY;
+		maskMaterial.maskFunction = MaskFunction;
 		maskMaterial.colorChannel = ColorChannel.GREEN;
 
 		/**
@@ -525,6 +525,10 @@ export class DepthOfFieldEffect extends Effect {
 
 		// The blur pass operates on the CoC buffer.
 		this.blurPass.initialize(renderer, alpha, UnsignedByteType);
+
+		const maskMaterial = this.maskPass.fullscreenMaterial;
+		maskMaterial.maskFunction = alpha ? MaskFunction.MULTIPLY :
+			MaskFunction.MULTIPLY_RGB_SET_ALPHA;
 
 		if(frameBufferType !== undefined) {
 


### PR DESCRIPTION
Reverts https://github.com/pmndrs/postprocessing/commit/5b4309a9155c8d97522747e9e4f9583784ada1b5 as discussed in Discord. https://codesandbox.io/s/y6vf55

| `MULTIPLY` | `MULTIPLY_RGB_SET_ALPHA` |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/23324155/235075610-e820fe4d-6992-4d62-ae99-0428accded3a.png) | ![image](https://user-images.githubusercontent.com/23324155/235075651-29634b49-1465-4f93-aebb-336f00d38575.png) |