### PR TITLE
fix: unpin peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"extends": "aether"
 	},
 	"peerDependencies": {
-		"three": ">= 0.138.0 < 0.153.0"
+		"three": ">= 0.138.0"
 	},
 	"devDependencies": {
 		"@tweakpane/core": "1.x.x",


### PR DESCRIPTION


### Description

Users with three version like 0.152.3 were getting dependency error when installing because max version was limited to 0.152.0

Following https://github.com/pmndrs/react-postprocessing/pull/209 and making it open ended

or we could add  `"three": ">= 0.138.x < 0.152.x"` 


