### PR TITLE
Clamp luminance to 0

### DIFF
--- a/src/materials/glsl/luminance.frag
+++ b/src/materials/glsl/luminance.frag
@@ -33,6 +33,7 @@ void main() {
 
 	vec4 texel = texture2D(inputBuffer, vUv);
 	float l = luminance(texel.rgb);
+	texel = max(texel, vec4(0.0));
 
 	#ifdef RANGE
 


### PR DESCRIPTION
Related issue: #547 

### Description

Artifacts were caused by negative texture value (not sure why), but clamping it to 0 fixed it. 