### PR TITLE
SSAOEffect: Mark options as optional in typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8102,10 +8102,10 @@ declare module "postprocessing" {
 				normalDepthBuffer?: Texture;
 				samples?: number;
 				rings?: number;
-				worldDistanceThreshold: number;
-				worldDistanceFalloff: number;
-				worldProximityThreshold: number;
-				worldProximityFalloff: number;
+				worldDistanceThreshold?: number;
+				worldDistanceFalloff?: number;
+				worldProximityThreshold?: number;
+				worldProximityFalloff?: number;
 				distanceThreshold?: number;
 				distanceFalloff?: number;
 				rangeThreshold?: number;


### PR DESCRIPTION
In index.d.ts, the `world*` options are not marked as optional in the SSAOEffect constructor, despite being handled as such in the code. This fixes that.