### PR TITLE
new DitheringEffect

### DIFF
--- a/manual/assets/js/src/demos/dithering.ts
+++ b/manual/assets/js/src/demos/dithering.ts
@@ -1,0 +1,171 @@
+import {
+	CubeTextureLoader,
+	LoadingManager,
+	PerspectiveCamera,
+	SRGBColorSpace,
+	Scene,
+	Texture,
+	WebGLRenderer
+} from "three";
+
+import {
+	BloomEffect,
+	ClearPass,
+   DitheringEffect,
+   DitheringType,
+	EffectPass,
+	GeometryPass,
+	RenderPipeline,
+	ToneMappingEffect
+} from "postprocessing";
+
+import { GLTF, GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+
+import { Pane } from "tweakpane";
+import { SpatialControls } from "spatial-controls";
+import * as DefaultEnvironment from "../objects/DefaultEnvironment.js";
+import * as Utils from "../utils/index.js";
+
+function load(): Promise<Map<string, Texture | GLTF>> {
+
+	const assets = new Map<string, Texture | GLTF>();
+	const loadingManager = new LoadingManager();
+	const gltfLoader = new GLTFLoader(loadingManager);
+	const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+
+	return new Promise<Map<string, Texture | GLTF>>((resolve, reject) => {
+
+		loadingManager.onLoad = () => resolve(assets);
+		loadingManager.onError = (url) => reject(new Error(`Failed to load ${url}`));
+
+		cubeTextureLoader.load(Utils.getSkyboxUrls("space", ".jpg"), (t) => {
+
+			t.colorSpace = SRGBColorSpace;
+			assets.set("sky", t);
+
+		});
+
+		gltfLoader.load(
+			`${document.baseURI}models/emissive-strength-test/EmissiveStrengthTest.gltf`,
+			(gltf) => assets.set("emissive-strength-test", gltf)
+		);
+
+	});
+
+}
+
+window.addEventListener("load", () => void load().then((assets) => {
+
+	// Renderer
+
+	const renderer = new WebGLRenderer({
+		powerPreference: "high-performance",
+		antialias: false,
+		stencil: false,
+		depth: false
+	});
+
+	renderer.setPixelRatio(window.devicePixelRatio);
+	renderer.debug.checkShaderErrors = Utils.isLocalhost;
+
+	// Camera & Controls
+
+	const camera = new PerspectiveCamera();
+	const controls = new SpatialControls(camera.position, camera.quaternion, renderer.domElement);
+	const settings = controls.settings;
+	settings.rotation.sensitivity = 2.2;
+	settings.rotation.damping = 0.025;
+	settings.translation.damping = 0.1;
+	controls.position.set(0, 3, 18);
+	controls.lookAt(0, 3, 0);
+
+	// Scene, Lights, Objects
+
+	const scene = new Scene();
+	const skyMap = assets.get("sky") as Texture;
+	// scene.background = skyMap;
+	// scene.environment = skyMap;
+	// scene.fog = DefaultEnvironment.createFog();
+	// scene.add(DefaultEnvironment.createEnvironment());
+
+	const gltf = assets.get("emissive-strength-test") as GLTF;
+	gltf.scene.position.y = 3;
+	scene.add(gltf.scene);
+
+	// Post Processing
+
+	const bloomEffect = new BloomEffect({
+		luminanceThreshold: 1.0,
+		luminanceSmoothing: 0.0,
+		intensity: 9.31,
+		radius: 0.540,
+		levels: 8
+	});
+
+   bloomEffect.luminancePass.enabled = false
+
+   const ditheringEffect = new DitheringEffect({
+      intensity: 1.0,
+      ditheringType: DitheringType.LUMABASED
+	});
+
+	const pipeline = new RenderPipeline(renderer);
+	pipeline.add(
+		new ClearPass(),
+		new GeometryPass(scene, camera, { samples: 4 }),
+		new EffectPass(bloomEffect, ditheringEffect, new ToneMappingEffect())
+	);
+
+	// Settings
+
+	const container = document.getElementById("viewport")!;
+	const pane = new Pane({ container: container.querySelector<HTMLElement>(".tp")! });
+	const fpsGraph = Utils.createFPSGraph(pane);
+
+
+   const ditheringTypeOptions = Utils.enumToRecord(DitheringType);
+
+   const ditheringFolder = pane.addFolder({ title: "Dithering Settings" });
+	ditheringFolder.addBinding(ditheringEffect, "intensity", { min: 0, max: 10, step: 0.01 });
+   ditheringFolder.addBinding(ditheringEffect, "ditheringType", { options: ditheringTypeOptions });
+
+	const bloomFolder = pane.addFolder({ title: "Bloom Settings" });
+	bloomFolder.addBinding(bloomEffect, "intensity", { min: 0, max: 10, step: 0.01 });
+	bloomFolder.addBinding(bloomEffect.mipmapBlurPass, "radius", { min: 0, max: 1, step: 1e-3 });
+	bloomFolder.addBinding(bloomEffect.mipmapBlurPass, "levels", { min: 1, max: 10, step: 1 });
+	bloomFolder.addBinding(bloomEffect.resolution, "scale", { label: "resolution", min: 0.5, max: 1, step: 0.05 });
+
+	// Resize Handler
+
+	function onResize(): void {
+
+		const width = container.clientWidth;
+		const height = container.clientHeight;
+		camera.aspect = width / height;
+		camera.fov = Utils.calculateVerticalFoV(90, Math.max(camera.aspect, 16 / 9));
+		camera.updateProjectionMatrix();
+		pipeline.setSize(width, height);
+
+	}
+
+	window.addEventListener("resize", onResize);
+	onResize();
+
+	// Render Loop
+
+	pipeline.compile().then(() => {
+
+		container.prepend(renderer.domElement);
+
+		renderer.setAnimationLoop((timestamp) => {
+
+			fpsGraph.begin();
+			controls.update(timestamp);
+			pipeline.render(timestamp);
+			fpsGraph.end();
+
+		});
+
+	}).catch((e) => console.error(e));
+
+}));

--- a/manual/content/demos/special-effects/dithering.en.md
+++ b/manual/content/demos/special-effects/dithering.en.md
@@ -1,0 +1,14 @@
+---
+layout: single
+collection: sections
+title: Dithering
+draft: false
+menu:
+  demos:
+    parent: special-effects
+script: dithering
+---
+
+# Dithering
+
+### External Resources

--- a/src/effects/DitheringEffect.ts
+++ b/src/effects/DitheringEffect.ts
@@ -1,0 +1,97 @@
+import { Uniform } from "three";
+import { DitheringType } from "../enums/DitheringType.js";
+import { Effect } from "./Effect.js";
+
+import fragmentShader from "./shaders/dithering.frag";
+
+/**
+ * DitheringEffect options.
+ *
+ * @category Effects
+ */
+
+export interface DitheringEffectOptions {
+
+	/**
+     * The dithering intensity.
+     *
+     * @defaultValue 1.0
+     */
+
+	intensity?: number;
+
+	/**
+     * The dithering type.
+     *
+     * @defaultValue DitheringType.LUMABASED
+     */
+
+	ditheringType?: DitheringType;
+}
+
+/**
+ * A dithering effect.
+ *
+ * @category Effects
+ */
+
+export class DitheringEffect extends Effect {
+
+	/**
+     * Constructs a new dithering effect.
+     *
+     * @param options - The options.
+     */
+
+	constructor({
+		intensity = 1.0,
+		ditheringType = DitheringType.LUMABASED
+	}: DitheringEffectOptions = {}) {
+
+		super("DitheringEffect");
+
+		this.fragmentShader = fragmentShader;
+		this.ditheringType = ditheringType;
+
+		this.input.uniforms.set("intensity", new Uniform(intensity));
+
+	}
+
+	/**
+     * The dithering type.
+     */
+
+	get ditheringType(): DitheringType {
+
+		return this.input.defines.get("DITHERING_TYPE") as DitheringType;
+
+	}
+
+	set ditheringType(value: DitheringType) {
+
+		if(this.ditheringType !== value) {
+
+         this.input.defines.set("DITHERING_TYPE", value);
+			this.setChanged();
+
+		}
+
+	}
+
+	/**
+     * The dithering intensity.
+     */
+
+	get intensity(): number {
+
+		return this.input.uniforms.get("intensity")!.value as number;
+
+	}
+
+	set intensity(value: number) {
+
+		this.input.uniforms.get("intensity")!.value = value;
+
+	}
+
+}

--- a/src/effects/index.ts
+++ b/src/effects/index.ts
@@ -2,6 +2,7 @@ export * from "./blending/index.js";
 
 export * from "./BloomEffect.js";
 export * from "./ColorDepthEffect.js";
+export * from "./DitheringEffect.js";
 export * from "./Effect.js";
 export * from "./FXAAEffect.js";
 export * from "./HalftoneEffect.js";

--- a/src/effects/shaders/dithering.frag
+++ b/src/effects/shaders/dithering.frag
@@ -1,0 +1,60 @@
+#define NOISECOLOR 0
+#define ORDERED 1
+#define LUMABASED 2
+
+uniform float intensity;
+
+float rand(vec2 co) {
+  return fract(sin(dot(co, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+#if DITHERING_TYPE == ORDERED
+// Bayer matrix for ordered dithering.
+const mat4 bayerMatrix = mat4(
+    0.0/16.0,  8.0/16.0,  2.0/16.0, 10.0/16.0,
+   12.0/16.0,  4.0/16.0, 14.0/16.0,  6.0/16.0,
+    3.0/16.0, 11.0/16.0,  1.0/16.0,  9.0/16.0,
+   15.0/16.0,  7.0/16.0, 13.0/16.0,  5.0/16.0
+);
+
+vec3 orderedDithering(vec3 color, vec2 fragCoord) {
+  ivec2 pixelCoord = ivec2(fragCoord) & 3;
+  float bayerValue = bayerMatrix[pixelCoord.x][pixelCoord.y];
+  return color + (bayerValue - 0.5) * intensity * 0.01;
+}
+#endif
+
+#if DITHERING_TYPE == NOISECOLOR
+vec3 noiseDitheringColor(vec3 color, vec2 fragCoord) {
+  float grid_position = rand(fragCoord);
+  vec3 dither_shift_RGB = vec3(0.25 / 255.0, -0.25 / 255.0, 0.25 / 255.0);
+  dither_shift_RGB = mix(2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position);
+  return color + dither_shift_RGB * intensity;
+}
+#endif
+
+#if DITHERING_TYPE == LUMABASED
+vec3 lumaNoiseDithering(vec3 color, vec2 fragCoord) {
+  float luma = max(dot(color, vec3(0.2126, 0.7152, 0.0722)), 1e-6);
+  float noise = rand(fragCoord) - 0.5;
+  float ditheredLuma = luma + noise * intensity * 0.0015;
+  return color * (ditheredLuma / luma);
+}
+#endif
+
+vec3 doDither(vec3 color, vec2 fragCoord) {
+    #if DITHERING_TYPE == NOISECOLOR
+        return noiseDitheringColor(color, fragCoord);
+    #elif DITHERING_TYPE == ORDERED
+        return orderedDithering(color, fragCoord);
+    #elif DITHERING_TYPE == LUMABASED
+        return lumaNoiseDithering(color, fragCoord);
+    #else
+        return color;
+    #endif
+}
+
+vec4 mainImage(const in vec4 inputColor, const in vec2 uv, const in GData gData) {
+  vec2 fragCoord = uv * resolution.xy;
+  return vec4(doDither(inputColor.rgb, fragCoord), inputColor.a);
+}

--- a/src/enums/DitheringType.ts
+++ b/src/enums/DitheringType.ts
@@ -1,0 +1,26 @@
+/**
+ * An enumeration of dithering types.
+ *
+ * @category Enums
+ */
+
+export enum DitheringType {
+
+	/**
+	 * Noise-based color dithering.
+	 */
+
+	NOISECOLOR,
+
+	/**
+	 * Ordered dithering using a Bayer matrix.
+	 */
+
+	ORDERED,
+
+	/**
+	 * Luma-based noise dithering.
+	 */
+
+	LUMABASED
+}

--- a/src/enums/index.ts
+++ b/src/enums/index.ts
@@ -1,4 +1,5 @@
 export * from "./ColorChannel.js";
+export * from "./DitheringType.js";
 export * from "./DepthCopyMode.js";
 export * from "./DepthTestStrategy.js";
 export * from "./EffectShaderSection.js";

--- a/test/effects/DitheringEffect.js
+++ b/test/effects/DitheringEffect.js
@@ -1,0 +1,11 @@
+import test from "ava";
+import { DitheringEffect } from "postprocessing";
+
+test("can be created and destroyed", t => {
+
+	const object = new DitheringEffect();
+	object.dispose();
+
+	t.pass();
+
+});


### PR DESCRIPTION
Wanted more control over the dithering process, so I've made a custom effect pass for it 🤗

```ts
export interface DitheringEffectOptions {

	/**
     * The dithering intensity.
     *
     * @defaultValue 1.0
     */

	intensity?: number;

	/**
     * The dithering type.
     *
     * @defaultValue DitheringType.LUMABASED
     */

	ditheringType?: DitheringType;
}
```

Includes 3 types of dithering:
- Noise dithering pattern - color based
- Noise dithering pattern - luma (grayscale) based
- Ordered bayer

Made a demo and proper enums for it.

There's a problem that I cannot solve in the demo though. I cannot make the demo to trigger an update in the effect when changing between the enum options. Seems related to triggering changes when the `defines` change, and the shader not being recompiled with the new defines? Not sure. And I couldn't find a way to do it. 

This problem is also present in the `vignette`, `halftone`, and `tonemapping` demo.