### PR TITLE
CDL implementation for tone mapping

### DIFF
--- a/manual/assets/js/src/demos/tone-mapping.ts
+++ b/manual/assets/js/src/demos/tone-mapping.ts
@@ -11,6 +11,7 @@ import {
 } from "three";
 
 import {
+	CDLPreset,
 	ClearPass,
 	EffectPass,
 	GeometryPass,
@@ -21,6 +22,7 @@ import {
 } from "postprocessing";
 
 import { GLTF, GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { BindingApi } from "@tweakpane/core";
 import { Pane } from "tweakpane";
 import { SpatialControls } from "spatial-controls";
 import * as Utils from "../utils/index.js";
@@ -120,13 +122,25 @@ window.addEventListener("load", () => void load().then((assets) => {
 
 	// Settings
 
+	const params = {
+		preset: CDLPreset.DEFAULT
+	};
+
+	let binding: BindingApi | undefined;
+
 	const container = document.getElementById("viewport")!;
 	const pane = new Pane({ container: container.querySelector<HTMLElement>(".tp")! });
 	const fpsGraph = Utils.createFPSGraph(pane);
 	const folder = pane.addFolder({ title: "Settings" });
 	folder.addBinding(light, "intensity", { label: "lightIntensity", min: 0, max: 100, step: 0.1 });
 	folder.addBinding(renderer, "toneMappingExposure", { min: 0, max: 4, step: 0.01 });
-	folder.addBinding(effect, "toneMapping", { options: Utils.enumToRecord(ToneMapping) });
+
+	folder.addBinding(effect, "toneMapping", { options: Utils.enumToRecord(ToneMapping) })
+		.on("change", (e) => void (binding!.hidden = (e.value !== ToneMapping.AGX)));
+
+	binding = folder.addBinding(params, "preset", { label: "CDL preset", options: Utils.enumToRecord(CDLPreset) })
+		.on("change", (e) => effect.cdl.applyPreset(e.value));
+
 	Utils.addBlendModeBindings(folder, effect.blendMode);
 
 	// Resize Handler

--- a/manual/content/demos/color-grading/tone-mapping.en.md
+++ b/manual/content/demos/color-grading/tone-mapping.en.md
@@ -25,6 +25,15 @@ const toneMappingEffect = new ToneMappingEffect({
 > [!TIP]
 > Tone mapping should generally be applied late in a render pipeline, but before anti-aliasing and the final color space conversion.
 
+## Primary Color Grading
+
+The `ToneMappingEffect` uses the American Society of Cinematographers Color Decision List (ASC CDL) format to configure primary
+color grading information. This format defines the math for Slope, Offset, Power and Saturation and provides a way to influence the look of the tone-mapped image.
+
+> [!INFO]
+> Only `ToneMapping.AGX` currently supports CDL parameters.
+
 ## External Resources
 
 * [Tone Mapping Techniques](https://64.github.io/tonemapping)
+* [ASC CDL](https://en.wikipedia.org/wiki/ASC_CDL)

--- a/src/effects/ToneMappingEffect.ts
+++ b/src/effects/ToneMappingEffect.ts
@@ -1,17 +1,10 @@
+import { ShaderChunk } from "three";
+import { CDLPreset } from "../enums/CDLPreset.js";
 import { ToneMapping } from "../enums/ToneMapping.js";
+import { ColorDecisionList } from "../utils/ColorDecisionList.js";
 import { Effect } from "./Effect.js";
 
 import fragmentShader from "./shaders/tone-mapping.frag";
-
-const toneMappingOperators = new Map<ToneMapping, string>([
-	[ToneMapping.LINEAR, "LinearToneMapping(texel)"],
-	[ToneMapping.REINHARD, "ReinhardToneMapping(texel)"],
-	[ToneMapping.CINEON, "CineonToneMapping(texel)"],
-	[ToneMapping.ACES_FILMIC, "ACESFilmicToneMapping(texel)"],
-	[ToneMapping.AGX, "AgXToneMapping(texel)"],
-	[ToneMapping.NEUTRAL, "NeutralToneMapping(texel)"],
-	[ToneMapping.CUSTOM, "CustomToneMapping(texel)"]
-]);
 
 /**
  * ToneMappingEffect options.
@@ -29,6 +22,14 @@ export interface ToneMappingEffectOptions {
 
 	toneMapping?: ToneMapping;
 
+	/**
+	 * A CDL Preset. Only applies to {@link ToneMapping.AGX}.
+	 *
+	 * @defaultValue null
+	 */
+
+	cdlPreset?: CDLPreset | null;
+
 }
 
 /**
@@ -40,17 +41,39 @@ export interface ToneMappingEffectOptions {
 export class ToneMappingEffect extends Effect implements ToneMappingEffectOptions {
 
 	/**
+	 * ASC CDL settings for primary color grading.
+	 */
+
+	readonly cdl: ColorDecisionList;
+
+	/**
 	 * Constructs a new tone mapping effect.
 	 *
 	 * @param options - The options.
 	 */
 
-	constructor({ toneMapping = ToneMapping.AGX }: ToneMappingEffectOptions = {}) {
+	constructor({ toneMapping = ToneMapping.AGX, cdlPreset = null }: ToneMappingEffectOptions = {}) {
 
 		super("ToneMappingEffect");
 
-		this.fragmentShader = fragmentShader;
+		this.fragmentShader = fragmentShader.replace(
+			// Resolve the #include early to ensure that applyCDL gets prefixed.
+			// This is only necessary because the shader chunk uses a function from the effect shader.
+			"#include <tonemapping_pars_fragment>",
+			ShaderChunk.tonemapping_pars_fragment.replace(
+				/(color = AgXOutsetMatrix \* color;)/,
+				"color = applyCDL(color);\n$1"
+			)
+		);
+
+		this.cdl = new ColorDecisionList();
+		this.cdl.addEventListener("toggle", () => this.onCDLToggle());
+
+		this.input.uniforms.set("cdl", this.cdl.uniform);
+		this.input.defines.set("USE_CDL", true);
+
 		this.toneMapping = toneMapping;
+		this.cdl.applyPreset(cdlPreset);
 
 	}
 
@@ -65,21 +88,30 @@ export class ToneMappingEffect extends Effect implements ToneMappingEffectOption
 		if(this.toneMapping !== value) {
 
 			const defines = this.input.defines;
-			defines.clear();
 			defines.set("TONE_MAPPING", value);
-
-			const operator = toneMappingOperators.get(value);
-
-			if(operator === undefined) {
-
-				throw new Error(`Invalid tone mapping: ${value}`);
-
-			}
-
-			defines.set("toneMapping(texel)", operator);
 			this.setChanged();
 
 		}
+
+	}
+
+	/**
+	 * Performs tasks when the CDL is enabled or disabled.
+	 */
+
+	private onCDLToggle(): void {
+
+		if(this.cdl.enabled) {
+
+			this.input.defines.set("USE_CDL", true);
+
+		} else {
+
+			this.input.defines.delete("USE_CDL");
+
+		}
+
+		this.setChanged();
 
 	}
 

--- a/src/effects/shaders/tone-mapping.frag
+++ b/src/effects/shaders/tone-mapping.frag
@@ -1,7 +1,80 @@
+#ifdef USE_CDL
+
+	struct ColorDecisionList {
+		vec3 slope;
+		vec3 offset;
+		vec3 power;
+		float saturation;
+	};
+
+	uniform ColorDecisionList cdl;
+
+	/**
+	 * Applies ASC CDL v1.2 color grade to input color in an unspecified log or linear space.
+	 *
+	 * @see https://blender.stackexchange.com/a/55239/43930
+	 * @see https://docs.acescentral.com/specifications/acescc/
+	 * @param color - A color in a log space (such as LogC, ACEScc, or AgX Log).
+	 * @return - The transformed color (same color space).
+	 */
+
+	vec3 applyCDL(in vec3 color) {
+
+		// ASC CDL v1.2 explicitly requires Rec. 709 luminance coefficients.
+		float l = dot(color, vec3(0.2126, 0.7152, 0.0722));
+		vec3 v = max(color * cdl.slope + cdl.offset, 0.0);
+		vec3 pv = pow(v, cdl.power);
+
+		if(v.r > 0.0) { v.r = pv.r; }
+		if(v.g > 0.0) { v.g = pv.g; }
+		if(v.b > 0.0) { v.b = pv.b; }
+
+		return (v - l) * cdl.saturation + l;
+
+	}
+
+#else
+
+	#define applyCDL(color) color
+
+#endif
+
 #include <tonemapping_pars_fragment>
 
 vec4 mainImage(const in vec4 inputColor, const in vec2 uv, const in GData gData) {
 
-	return vec4(toneMapping(inputColor.rgb), inputColor.a);
+	vec3 result;
+
+	#if TONE_MAPPING == 0
+
+		result = LinearToneMapping(inputColor.rgb);
+
+	#elif TONE_MAPPING == 1
+
+		result = ReinhardToneMapping(inputColor.rgb);
+
+	#elif TONE_MAPPING == 2
+
+		result = CineonToneMapping(inputColor.rgb);
+
+	#elif TONE_MAPPING == 3
+
+		result = ACESFilmicToneMapping(inputColor.rgb);
+
+	#elif TONE_MAPPING == 4
+
+		result = AgXToneMapping(inputColor.rgb);
+
+	#elif TONE_MAPPING == 5
+
+		result = NeutralToneMapping(inputColor.rgb);
+
+	#elif TONE_MAPPING == 6
+
+		result = CustomToneMapping(inputColor.rgb);
+
+	#endif
+
+	return vec4(result, inputColor.a);
 
 }

--- a/src/enums/CDLPreset.ts
+++ b/src/enums/CDLPreset.ts
@@ -1,0 +1,35 @@
+/**
+ * An enumeration of CDL presets for different looks.
+ *
+ * @category Enums
+ */
+
+export enum CDLPreset {
+
+	/**
+	 * The baseline look.
+	 *
+	 * Good for testing, but not well suited for production use due to flat colors.
+	 */
+
+	DEFAULT,
+
+	/**
+	 * A warmer look with more vivid colors.
+	 */
+
+	GOLDEN,
+
+	/**
+	 * Punchy colors with more saturation and higher contrast.
+	 */
+
+	PUNCHY,
+
+	/**
+	 * Similar to the punchy preset, but with lower contrast.
+	 */
+
+	NEEDLE
+
+}

--- a/src/enums/ToneMapping.ts
+++ b/src/enums/ToneMapping.ts
@@ -11,7 +11,7 @@ export enum ToneMapping {
 	 * No tone mapping, only exposure. Colors will be clamped to the output range.
 	 */
 
-	LINEAR,
+	LINEAR = 0,
 
 	/**
 	 * Basic Reinhard tone mapping.
@@ -19,7 +19,7 @@ export enum ToneMapping {
 	 * @see https://www.cs.utah.edu/docs/techreports/2002/pdf/UUCS-02-001.pdf
 	 */
 
-	REINHARD,
+	REINHARD = 1,
 
 	/**
 	 * Optimized filmic operator by Jim Hejl and Richard Burgess-Dawson.
@@ -27,13 +27,13 @@ export enum ToneMapping {
 	 * @see http://filmicworlds.com/blog/filmic-tonemapping-operators
 	 */
 
-	CINEON,
+	CINEON = 2,
 
 	/**
 	 * ACES filmic tone mapping with a scale of 1.0/0.6.
 	 */
 
-	ACES_FILMIC,
+	ACES_FILMIC = 3,
 
 	/**
 	 * Filmic tone mapping based on Blender's implementation using rec 2020 primaries.
@@ -41,7 +41,7 @@ export enum ToneMapping {
 	 * @see https://github.com/EaryChow/AgX
 	 */
 
-	AGX,
+	AGX = 4,
 
 	/**
 	 * Neutral tone mapping by Khronos.
@@ -50,7 +50,7 @@ export enum ToneMapping {
 	 * @see https://modelviewer.dev/examples/tone-mapping
 	 */
 
-	NEUTRAL,
+	NEUTRAL = 5,
 
 	/**
 	 * Custom tone mapping.
@@ -60,6 +60,6 @@ export enum ToneMapping {
 	 * @see https://threejs.org/docs/?q=shader#api/en/renderers/shaders/ShaderChunk
 	 */
 
-	CUSTOM
+	CUSTOM = 6
 
 }

--- a/src/enums/index.ts
+++ b/src/enums/index.ts
@@ -1,4 +1,5 @@
 export * from "./ColorChannel.js";
+export * from "./CDLPreset.js";
 export * from "./DepthCopyMode.js";
 export * from "./DepthTestStrategy.js";
 export * from "./EffectShaderSection.js";

--- a/src/utils/ColorDecisionList.ts
+++ b/src/utils/ColorDecisionList.ts
@@ -1,0 +1,172 @@
+import { BaseEvent, EventDispatcher, Uniform, Vector3 } from "three";
+import { CDLPreset } from "../enums/CDLPreset.js";
+
+/**
+ * ASC CDL events.
+ *
+ * @category Utils
+ */
+
+export interface CDLEventMap {
+
+	toggle: BaseEvent;
+
+}
+
+/**
+ * ASC CDL v1.2.
+ *
+ * The American Society of Cinematographers Color Decision List (ASC CDL) is a format for the exchange of basic primary
+ * color grading information between equipment and software from different manufacturers. The format defines the math
+ * for Slope, Offset, Power and Saturation.
+ *
+ * @see https://en.wikipedia.org/wiki/ASC_CDL
+ * @see https://github.com/mrdoob/three.js/pull/28544
+ * @category Utils
+ */
+
+export class ColorDecisionList extends EventDispatcher<CDLEventMap> {
+
+	/**
+	 * A uniform that contains the combined CDL data for use in a shader.
+	 */
+
+	readonly uniform: Uniform<{
+		slope: Vector3;
+		offset: Vector3;
+		power: Vector3;
+		saturation: number;
+	}>;
+
+	/**
+	 * @see {@link enabled}
+	 */
+
+	private _enabled: boolean;
+
+	/**
+	 * Constructs a new CDL configuration.
+	 */
+
+	constructor() {
+
+		super();
+
+		this.uniform = new Uniform({
+			slope: new Vector3(1.0, 1.0, 1.0),
+			offset: new Vector3(0.0, 0.0, 0.0),
+			power: new Vector3(1.0, 1.0, 1.0),
+			saturation: 1.0
+		});
+
+		this._enabled = true;
+
+	}
+
+	/**
+	 * Indicates whether this CDL is enabled.
+	 */
+
+	get enabled(): boolean {
+
+		return this._enabled;
+
+	}
+
+	set enabled(value: boolean) {
+
+		this._enabled = value;
+		this.dispatchEvent({ type: "toggle" });
+
+	}
+
+	/**
+	 * The slope. Valid values: (0 ≤ Slope < +Infinity).
+	 */
+
+	get slope(): Vector3 {
+
+		return this.uniform.value.slope;
+
+	}
+
+	/**
+	 * The offset. Valid values: (-Infinity < Offset < +Infinity)
+	 */
+
+	get offset(): Vector3 {
+
+		return this.uniform.value.offset;
+
+	}
+
+
+	/**
+	 * The power. Valid values: (0 < Power < +Infinity)
+	 */
+
+	get power(): Vector3 {
+
+		return this.uniform.value.power;
+
+	}
+
+	/**
+	 * The saturation. Valid values: (0 ≤ Saturation < +Infinity)
+	 */
+
+	get saturation(): number {
+
+		return this.uniform.value.saturation;
+
+	}
+
+	set saturation(value: number) {
+
+		this.uniform.value.saturation = value;
+
+	}
+
+	/**
+	 * Applies the given CDL preset.
+	 *
+	 * @param preset - The preset.
+	 */
+
+	applyPreset(preset: CDLPreset | null): void {
+
+		switch(preset) {
+
+			case CDLPreset.DEFAULT:
+				this.offset.set(0.0, 0.0, 0.0);
+				this.slope.set(1.0, 1.0, 1.0);
+				this.power.set(1.0, 1.0, 1.0);
+				this.saturation = 1.0;
+				break;
+
+			case CDLPreset.GOLDEN:
+				this.offset.set(0.0, 0.0, 0.0);
+				this.slope.set(1.0, 0.9, 0.5);
+				this.power.set(0.8, 0.8, 0.8);
+				this.saturation = 0.8;
+				break;
+
+			case CDLPreset.PUNCHY:
+				this.offset.set(0.0, 0.0, 0.0);
+				this.slope.set(1.0, 1.0, 1.0);
+				this.power.set(1.35, 1.35, 1.35);
+				this.saturation = 1.4;
+				break;
+
+			case CDLPreset.NEEDLE:
+				this.offset.set(0.0, 0.0, 0.0);
+				this.slope.set(1.05, 1.05, 1.05);
+				this.power.set(1.1, 1.1, 1.1);
+				this.saturation = 1.15;
+				break;
+
+		}
+
+	}
+
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,6 +4,7 @@ export * from "./gbuffer/index.js";
 export * from "./Background.js";
 export * from "./ClearFlags.js";
 export * from "./ClearValues.js";
+export * from "./ColorDecisionList.js";
 export * from "./EffectMaterialManager.js";
 export * from "./EffectShaderData.js";
 export * from "./GaussKernel.js";


### PR DESCRIPTION
Related issue: #584 

### Description

This PR implements CDL for AgX tone mapping. It's based on https://github.com/mrdoob/three.js/pull/27618 and https://github.com/mrdoob/three.js/pull/29510.

The API looks like this:

```ts
const toneMappingEffect = new ToneMappingEffect({
  toneMapping: ToneMapping.AGX,
  cdlPreset: CDLPreset.PUNCHY
});

const cdl = toneMappingEffect.cdl;
cdl.slope.set(...);
cdl.offset.set(...);
cdl.power.set(...);
cdl.saturation = ...;

cdl.applyPreset(CDLPreset.DEFAULT);
```

I've also included the preset from Needle Engine that @hybridherbst posted [here](https://github.com/mrdoob/three.js/pull/27618#issuecomment-3052523641) for good measure.

I had hoped that CDL would eventually land in `three`, and not just for TSL because it would've made the integration process much easier. Now it's a bit on the messier side since it requires shader chunk manipulation.

Feedback is welcome @donmccurdy, @hybridherbst and anyone else who might be interested.